### PR TITLE
Fix installation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-socket
+sockets
 scapy
 django
-random
-threading
+random2
+threaded


### PR DESCRIPTION
### Issue
Installation fails as some of the dependant libraries in requirements doesn't exist

### Fix
Update requirements file (without sticking the version)

